### PR TITLE
List as provider of psr/simple-cache-implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
             "email": "patrick.d.hayes@gmail.com"
         }
     ],
+    "provide": {
+        "psr/simple-cache-implementation": "1.0"
+    }
     "autoload": {
         "psr-4": {
             "HighWire\\DrupalPSR16\\": "src/"


### PR DESCRIPTION
This will ensure this project is listed on https://packagist.org/providers/psr/simple-cache-implementation?type=composer-plugin