### PR TITLE
Declare forward compatibility to PSR Simple Cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
         "drupal/core": "~8.3"
     },
     "require": {
-        "psr/simple-cache": "^1.0"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     }
 }


### PR DESCRIPTION
Add Simple Cache 2.0 and 3.0 compatibility to composer json so this is more flexible to use.

None of the 2.0 and 3.0 changes would break this library. And future cache libraries might depends on newer spec of Simple Cache.